### PR TITLE
Remove CoroutineState->nestingLevel

### DIFF
--- a/lib/CoroutineState.php
+++ b/lib/CoroutineState.php
@@ -15,5 +15,4 @@ class CoroutineState {
     public $generator;
     public $returnValue;
     public $currentPromise;
-    public $nestingLevel;
 }

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -773,7 +773,6 @@ function resolve($generator) {
     $cs->generator = $generator;
     $cs->returnValue = null;
     $cs->currentPromise = null;
-    $cs->nestingLevel = 0;
     $cs->reactor = reactor();
 
     __coroutineAdvance($cs);
@@ -799,10 +798,8 @@ function __coroutineAdvance(CoroutineState $cs) {
                 $cs->promisor->succeed($result);
             }
         } elseif ($yielded instanceof Promise) {
-            if ($cs->nestingLevel < 3) {
-                $cs->nestingLevel++;
+            if ($cs->generator->valid()) {
                 $yielded->when('Amp\__coroutineSend', $cs);
-                $cs->nestingLevel--;
             } else {
                 $cs->currentPromise = $yielded;
                 $cs->reactor->immediately('Amp\__coroutineNextTick', ["cb_data" => $cs]);


### PR DESCRIPTION
In certain scenarios yielding more than 3 Promises in an Amp context
would result in the 4th and consecutive Promises to never resolve. This
appears to have been due to an arbitrary nestingLevel check that
determined when Amp__coroutineSend was called. For this scenario
Amp__coroutineNextTick should be invoked as the Generator has not
finished yielding.

This patch changes the nestingLevel check to now run Amp__coroutineSend
based on Generator->valid, ensuring that all values are yielded from the
Generator. As the CoroutineState->nestingLevel value was only used for
these checks it was removed from the CoroutineState.
